### PR TITLE
Fixes for JDK-6997628.

### DIFF
--- a/src/main/java/com/trimble/tekla/teamcity/HttpConnector.java
+++ b/src/main/java/com/trimble/tekla/teamcity/HttpConnector.java
@@ -42,7 +42,8 @@ public class HttpConnector {
             connection.setDoOutput(true);
             connection.setConnectTimeout(5000);
             connection.setRequestProperty("Authorization", "Basic " + authEncoded);
-            connection.setRequestProperty("Content-Length", "0");
+            connection.setRequestProperty("Content-Length", "0"); //JDK-6997628
+            connection.getOutputStream().close();
             
             InputStream content = (InputStream)connection.getInputStream();
             BufferedReader in   = 
@@ -141,8 +142,9 @@ public class HttpConnector {
         connection.setRequestProperty("Authorization", "Basic " + authEncoded);
         if (payload != null) {
           connection.setRequestProperty("Content-Type", "application/xml; charset=utf-8");
-          connection.setRequestProperty("Content-Length", Integer.toString(payload.length()));
+          connection.setRequestProperty("Content-Length", Integer.toString(payload.length())); //JDK-6997628
           connection.getOutputStream().write(payload.getBytes("UTF8"));
+          connection.getOutputStream().close();
         }
 
         InputStream content = (InputStream)connection.getInputStream();


### PR DESCRIPTION
Content-Length header cannot be set with setRequestProperty anymore according to JDK-6997628. Added close for output streams, so the header is added on new versions of Java.