### PR TITLE
Add support for cancelation of builds with snapshot dependencies

### DIFF
--- a/src/main/java/com/trimble/tekla/pojo/Trigger.java
+++ b/src/main/java/com/trimble/tekla/pojo/Trigger.java
@@ -25,6 +25,7 @@ public class Trigger {
   private String triggerInclusion;
   private String triggerExclusion;
   private boolean cancelRunningBuilds;
+  private boolean cancelDependencies;
   private boolean triggerOnEmptyBranches;
   private boolean hideOnPullRequest;
   private boolean triggerWhenNoReviewers;
@@ -59,6 +60,14 @@ public class Trigger {
 
   public void setCancelRunningBuilds(final boolean cancelRunningBuilds) {
     this.cancelRunningBuilds = cancelRunningBuilds;
+  }
+
+  public boolean isCancelDependencies() {
+    return this.cancelDependencies;
+  }
+
+  public void setCancelDependencies(final boolean cancelDependencies) {
+    this.cancelDependencies = cancelDependencies;
   }
 
   public boolean isTriggerOnPullRequest() {

--- a/src/main/java/com/trimble/tekla/rest/TeamctiyRest.java
+++ b/src/main/java/com/trimble/tekla/rest/TeamctiyRest.java
@@ -283,7 +283,7 @@ public class TeamctiyRest extends RestResource {
           continue;
         }
         try {
-          final String returnData = this.connector.GetBuildsForBranch(conf, buildConfig.getBranchConfig(), buildConfig.getTarget(), settings.get(), repository.getName());
+          final String returnData = this.connector.GetBuildsForBranch(conf, buildConfig.getBranchConfig(), buildConfig.getTarget(), settings.get(), repository.getName(), false);
           final String queueData = this.connector.GetQueueDataForConfiguration(conf, buildConfig.getTarget(), settings.get(), repository.getName());
           jObj.put(buildConfig.getTarget(), returnData);
           jObj.put(buildConfig.getTarget() + "_queue", queueData);
@@ -343,7 +343,7 @@ public class TeamctiyRest extends RestResource {
         for (final Trigger buildConfig : configurations) {
           if ("build".equals(buildConfig.getDownStreamTriggerType()) && !"".equals(buildConfig.getDownStreamTriggerTarget())) {
             final String depBuildId = buildConfig.getTarget();
-            final String returnData = this.connector.GetBuildsForBranch(conf, buildConfig.getBranchConfig(), depBuildId, settings.get(), repository.getName());
+            final String returnData = this.connector.GetBuildsForBranch(conf, buildConfig.getBranchConfig(), depBuildId, settings.get(), repository.getName(), false);
             final String queueData = this.connector.GetQueueDataForConfiguration(conf, depBuildId, settings.get(), repository.getName());
             jObj.put(depBuildId + "_dep_wref", url + "/viewType.html?buildTypeId=" + depBuildId);
             jObj.put(depBuildId + "_dep", returnData);
@@ -351,7 +351,7 @@ public class TeamctiyRest extends RestResource {
 
             final String [] downBuildIds = buildConfig.getDownStreamTriggerTarget().split(",");           
             for (String downBuildId : downBuildIds) {
-                final String returnDataBuildDep = this.connector.GetBuildsForBranch(conf, buildConfig.getBranchConfig(), downBuildId, settings.get(), repository.getName());
+                final String returnDataBuildDep = this.connector.GetBuildsForBranch(conf, buildConfig.getBranchConfig(), downBuildId, settings.get(), repository.getName(), false);
                 final String queueDataBuildDep = this.connector.GetQueueDataForConfiguration(conf, downBuildId, settings.get(), repository.getName());
                 jObj.put(downBuildId + "_build", returnDataBuildDep);
                 jObj.put(downBuildId + "_build_branch", buildConfig.getBranchConfig());                
@@ -371,7 +371,7 @@ public class TeamctiyRest extends RestResource {
               "tab".equals(buildConfig.getDownStreamTriggerType()) && !"".equals(buildConfig.getDownStreamTriggerTarget())) {
             final String depBuildId = buildConfig.getTarget();
             
-            final String returnData = this.connector.GetBuildsForBranch(conf, buildConfig.getBranchConfig(), depBuildId, settings.get(), repository.getName());
+            final String returnData = this.connector.GetBuildsForBranch(conf, buildConfig.getBranchConfig(), depBuildId, settings.get(), repository.getName(), false);
             final String queueData = this.connector.GetQueueDataForConfiguration(conf, depBuildId, settings.get(), repository.getName());
             jObj.put(depBuildId + "_dep", returnData);
             jObj.put(depBuildId + "_dep_wref", url + "/viewType.html?buildTypeId=" + depBuildId);

--- a/src/main/resources/i18n/teamcity-trigger-hook.properties
+++ b/src/main/resources/i18n/teamcity-trigger-hook.properties
@@ -17,6 +17,7 @@ triggers.button.add=Add
 triggers.button.export=Export Triggers
 triggers.button.import=Import Triggers
 triggers.cancel.builds=Cancel Running Builds
+triggers.cancel.dependencies=Cancel Running Dependencies
 triggers.pull.request=Trigger on Pull Request
 triggers.pull.hideonprdialog=Hide on Pull Request Dialog
 triggers.empty.branches=Trigger on "Empty" Branches
@@ -30,6 +31,7 @@ triggers.no.reviewers=No Reviewers
 
 triggers.column.regex=Regex
 triggers.column.cancel.builds=Cancel
+triggers.column.cancel.dependencies=Cancel dependencies
 triggers.column.pull.request=On pull
 triggers.column.hide=Hide
 triggers.column.empty.branches=On empty

--- a/src/main/resources/static/repository-triggers-tab.js
+++ b/src/main/resources/static/repository-triggers-tab.js
@@ -21,6 +21,7 @@ require([
         _$hideOnPullRequest : undefined,
         _$triggerWhenNoReviewers : undefined,
         _$cancelRunningBuilds : undefined,
+        _$cancelDependencies : undefined,
         _$downStreamTriggerDescription : undefined,
         _$downStreamTriggerType : undefined,
         _$downStreamTriggerTarget : undefined,
@@ -58,6 +59,7 @@ require([
             this._$triggerOnPullRequest = $('#triggerOnPullRequest');
             this._$hideOnPullRequest = $('#hideOnPullRequest');
             this._$cancelRunningBuilds = $('#cancelRunningBuilds');
+            this._$cancelDependencies = $('#cancelDependencies');
             this._$downStreamTriggerType = $('#downStreamTriggerType');
             this._$downStreamTriggerDescription = $('#downStreamTriggerDescription');
             this._$downStreamTriggerTarget = $('#downStreamTriggerTarget');
@@ -100,6 +102,9 @@ require([
             if(typeof trigger.triggerOnEmptyBranches === 'undefined'){
                 trigger.triggerOnEmptyBranches = true;
             }            
+            if(typeof trigger.cancelDependencies === 'undefined'){
+                trigger.cancelDependencies = false;
+            }            
             var $tableRow = $('<tr/>', {
                 html : [$('<td/>', {
                     html : $.proxy(function() {
@@ -135,6 +140,12 @@ require([
                             text : AJS.I18n.getText('triggers.column.cancel.builds')
                         }), $('<span/>', {
                             text : trigger.cancelRunningBuilds
+                        })]
+                    }), $('<span/>', {
+                        html : [$('<span/>', {
+                            text : AJS.I18n.getText('triggers.column.cancel.dependencies')
+                        }), $('<span/>', {
+                            text : trigger.cancelDependencies
                         })]
                     }), $('<span/>', {
                         html : [$('<span/>', {
@@ -239,6 +250,7 @@ require([
                 triggerOnPullRequest : this._$triggerOnPullRequest[0].checked,
                 hideOnPullRequest : this._$hideOnPullRequest[0].checked,
                 cancelRunningBuilds : this._$cancelRunningBuilds[0].checked,
+                cancelDependencies : this._$cancelDependencies[0].checked,
                 triggerInclusion : this._$triggerInclusion.val(),
                 triggerExclusion : this._$triggerExclusion.val(),
                 downStreamTriggerType : this._$downStreamTriggerType.val(),
@@ -258,6 +270,7 @@ require([
             this._$triggerOnPullRequest[0].checked = false;
             this._$hideOnPullRequest[0].checked = false;
             this._$cancelRunningBuilds[0].checked = false;
+            this._$cancelDependencies[0].checked = false;
 
             var triggerUUID = uuid();
             this._triggers[triggerUUID] = trigger;

--- a/src/main/resources/static/repository-triggers-tab.soy
+++ b/src/main/resources/static/repository-triggers-tab.soy
@@ -51,6 +51,10 @@
                 {param labelText: getText('triggers.cancel.builds') /}
             {/call}
             {call .toggle}
+                {param id: 'cancelDependencies' /}
+                {param labelText: getText('triggers.cancel.dependencies') /}
+            {/call}
+            {call .toggle}
                 {param id: 'triggerOnPullRequest' /}
                 {param labelText: getText('triggers.pull.request') /}
             {/call}


### PR DESCRIPTION
In the current state, the plugin assumes that if a target build in the queue, it will always run the latest revision and will not try to cancel it.

This is not always the case for builds with snapshot dependency.
Based on the teamcity configuration, a snapshot dependencies can enforce the revision of a queued build if one of the dependencies has already started

For example:
Triggering a build **A** with a snapshot dependency **B** configured with "Enforce revisions synchronization".
As soon as **B** leave the queue, it will enforce the revision on the build **A**, if the VCS root is the same for both builds

The plugin now will ensure the revision of the target build is correct before skipping it and will cancel any non reused dependencies.